### PR TITLE
Return properly typed reports from KSCrashReportFilterConcatenate

### DIFF
--- a/Sources/KSCrashFilters/KSCrashReportFilterBasic.m
+++ b/Sources/KSCrashFilters/KSCrashReportFilterBasic.m
@@ -264,7 +264,7 @@
             id object = [KSNSDictionaryHelper objectInDictionary:report.value forKeyPath:key];
             [concatenated appendFormat:@"%@", object];
         }
-        [filteredReports addObject:concatenated];
+        [filteredReports addObject:[KSCrashReportString reportWithValue:concatenated]];
     }
     kscrash_callCompletion(onCompletion, filteredReports, nil);
 }


### PR DESCRIPTION
Currently, `KSCrashReportFilterConcatenate` doesn't return `KSCrashReportString`, but a plain `NSString`.
This will confuse other filters coming after it (for example `KSCrashReportFilterStringToData`).

This PR fixes this.